### PR TITLE
Add config validation and solver debugging info

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,13 @@ optimisation work.
 - Teacher workload constraints respected
 - Intuitive user adoption by scheduling team
 - Significant time savings over current spreadsheet method
+
+## Understanding Validation Errors
+`timetable_ortools.py` performs basic sanity checks before building the CP-SAT
+model. Each class may request at most `len(DAYS) * len(PERIODS)` periods per
+week and teachers may have optional limits defined in `teacher_limits`.
+
+If these limits are exceeded, the script raises a `ValueError` naming the class
+or teacher and showing the offending totals. When the solver cannot find a
+feasible timetable, it prints the same totals for all classes and teachers so
+you can quickly locate over-subscribed resources.


### PR DESCRIPTION
## Summary
- validate teacher and class load in `timetable_ortools`
- show totals if the CP-SAT model has no solution
- document how to read validation errors in README

## Testing
- `python3 -m py_compile timetable_ortools.py`
- `python3 timetable_ortools.py` *(fails: Class G10 requests 46 periods but only 45 slots are available)*

------
https://chatgpt.com/codex/tasks/task_e_6889e642cbdc8333b5ce5598aab1b518