### PR TITLE
Refactor timetable_ortools to library

### DIFF
--- a/schedule_output.py
+++ b/schedule_output.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Utility functions for displaying generated schedules."""
+
+from __future__ import annotations
+from typing import Dict, Tuple
+
+DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+PERIODS = list(range(1, 10))
+
+
+def output_timetable(timetables: Dict[str, Dict[Tuple[str, int], Dict[str, str]]]):
+    """Print the timetable for each class."""
+    for class_name, tt in timetables.items():
+        print(f"\nTimetable for {class_name}:")
+        for day in DAYS:
+            print(day + ":")
+            for period in PERIODS:
+                entry = tt.get((day, period))
+                if entry:
+                    print(
+                        f"  Period {period}: {entry['course']} (Teacher: {entry['teacher']})"
+                    )
+                else:
+                    print(f"  Period {period}: Free")
+
+
+def output_teacher_schedule(timetables: Dict[str, Dict[Tuple[str, int], Dict[str, str]]], teacher: str):
+    """Print the weekly schedule for a given teacher name."""
+    schedule: Dict[Tuple[str, int], Tuple[str, str]] = {}
+    for class_name, tt in timetables.items():
+        for (day, period), entry in tt.items():
+            if entry and entry.get("teacher") == teacher:
+                schedule[(day, period)] = (class_name, entry["course"])
+
+    print(f"\nSchedule for {teacher}:")
+    for day in DAYS:
+        print(day + ":")
+        for period in PERIODS:
+            cls_course = schedule.get((day, period))
+            if cls_course:
+                cls, course = cls_course
+                print(f"  Period {period}: {course} with {cls}")
+            else:
+                print(f"  Period {period}: Free")

--- a/timetable.py
+++ b/timetable.py
@@ -1,92 +1,13 @@
 #!/usr/bin/env python3
-import yaml
-import sys
-import pandas as pd
-import random
+"""Wrapper script that generates a timetable using OR-Tools."""
 
-DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
-PERIODS = list(range(1, 10))
+from timetable_ortools import load_config, solve_timetable
+from schedule_output import output_timetable
 
 
-def load_config(filename="config.yaml"):
-    try:
-        with open(filename, "r", encoding="utf-8") as f:
-            return yaml.safe_load(f)
-    except Exception as e:
-        sys.exit(f"Error loading config.yaml: {e}")
-
-
-def schedule_timetables(config):
-    teachers = {t["id"]: t["name"] for t in config.get("teachers", [])}
-    courses = {
-        c["id"]: {"name": c["name"], "teacher_id": c["teacher_id"]}
-        for c in config.get("courses", [])
-    }
-    teacher_limits = config.get("teacher_limits", {})
-
-    timetables = {
-        class_name: {(day, period): None for day in DAYS for period in PERIODS}
-        for class_name in config["classes"]
-    }
-
-    global_assignments = {}
-
-    for teacher_id in teachers:
-        global_assignments[teacher_id] = []
-
-    for class_name, class_info in config["classes"].items():
-        for course_assignment in class_info.get("courses", []):
-            course_id = course_assignment["course_id"]
-            periods = course_assignment["periods_per_week"]
-            course = courses.get(course_id)
-            if not course:
-                continue
-
-            teacher_id = course["teacher_id"]
-
-            for _ in range(periods):
-                available_slots = [
-                    (day, period)
-                    for day in DAYS
-                    for period in PERIODS
-                    if timetables[class_name][(day, period)] is None
-                ]
-                random.shuffle(available_slots)
-
-                for day, period in available_slots:
-                    if len(global_assignments[teacher_id]) >= teacher_limits.get(
-                        teacher_id, 15
-                    ):
-                        continue
-
-                    timetables[class_name][(day, period)] = {
-                        "course": course["name"],
-                        "teacher": teachers[teacher_id],
-                    }
-                    global_assignments[teacher_id].append((day, period))
-                    break
-
-    return timetables
-
-
-def output_timetable(timetables):
-    for class_name, tt in timetables.items():
-        print(f"\nTimetable for {class_name}:")
-        for day in DAYS:
-            print(day + ":")
-            for period in PERIODS:
-                entry = tt.get((day, period))
-                if entry:
-                    print(
-                        f"  Period {period}: {entry['course']} (Teacher: {entry['teacher']})"
-                    )
-                else:
-                    print(f"  Period {period}: Free")
-
-
-def main():
-    config = load_config()
-    timetable = schedule_timetables(config)
+def main() -> None:
+    cfg = load_config()
+    timetable = solve_timetable(cfg)
     output_timetable(timetable)
 
 

--- a/timetable_ortools.py
+++ b/timetable_ortools.py
@@ -176,10 +176,3 @@ def solve_timetable(config: Dict):
     return timetables
 
 
-if __name__ == "__main__":
-    cfg = load_config()
-    timetable = solve_timetable(cfg)
-    # Reuse output_timetable from timetable.py for printing if available
-    from timetable import output_timetable
-
-    output_timetable(timetable)


### PR DESCRIPTION
## Summary
- remove `__main__` logic from `timetable_ortools.py`
- keep wrapper script `timetable.py` as the entry point

## Testing
- `python3 timetable.py` *(fails: Class G10 requests 46 periods but only 45 slots are available)*
- `python3 timetable_ortools.py` *(no output: module now library only)*
- `python3 - <<'PY'
from schedule_output import output_teacher_schedule
sample = {
    'Class1': {('Monday',1): {'course':'Math','teacher':'Alice'},
                ('Monday',2): {'course':'Eng','teacher':'Bob'},
                ('Tuesday',1): {'course':'Math','teacher':'Alice'}},
    'Class2': {('Monday',1): {'course':'Sci','teacher':'Bob'},
                ('Tuesday',2): {'course':'Eng','teacher':'Alice'}}}
output_teacher_schedule(sample, 'Alice')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6889eacffbb08333b5154435d88a4558