### PR TITLE
Add PostgreSQL initialization utilities and CI test configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,4 +5,30 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_HOST: localhost
+      POSTGRES_PORT: 5432
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pytest

--- a/README.md
+++ b/README.md
@@ -170,3 +170,15 @@ The system includes real sample data representing:
 **International Constraints**: Approximately 40% of teachers are international with specific availability restrictions.
 
 This system replaces a manual spreadsheet-based scheduling process and aims to optimize both educational outcomes and administrative efficiency while maintaining the flexibility needed for a small international school environment.
+## Development Setup
+
+The project provides helper functions in `db.py` to initialise the PostgreSQL schema and read data from the database.
+
+```python
+from db import init_db, display_students
+
+init_db()            # create tables using schema.sql
+display_students()   # print student records
+```
+
+Tests rely on a running PostgreSQL instance. Locally ensure the server is available and the `POSTGRES_*` environment variables are set. The CI workflow uses a PostgreSQL service container so tests run automatically.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pyyaml
 ortools
 pytest
+
+psycopg2-binary

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from db import init_db, get_students, get_connection
+
+
+def test_init_and_display():
+    os.environ.setdefault("POSTGRES_DB", "postgres")
+    os.environ.setdefault("POSTGRES_USER", "postgres")
+    os.environ.setdefault("POSTGRES_PASSWORD", "postgres")
+    os.environ.setdefault("POSTGRES_HOST", "localhost")
+    os.environ.setdefault("POSTGRES_PORT", "5432")
+
+    init_db()
+
+    conn = get_connection()
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO students (student_id, name, grade_level) VALUES (%s, %s, %s)",
+            ("S1", "Alice", 10),
+        )
+    conn.close()
+
+    rows = get_students()
+    assert any(r[1] == "S1" and r[2] == "Alice" and r[3] == 10 for r in rows)


### PR DESCRIPTION
## Summary
- add database helper to initialise PostgreSQL schema and print students
- include basic pytest using PostgreSQL
- configure GitHub Actions with PostgreSQL service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e9f750f483339361748c506fe07f