### PR TITLE
Add student CRUD helpers

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,4 +1,6 @@
 import os
+from typing import Optional
+
 import psycopg2
 
 
@@ -58,7 +60,7 @@ def display_students():
         print(row)
 
 
-def add_student(student_id: int, name: str, grade_level: int):
+def add_student(student_id: str, name: str, grade_level: int):
     """Insert a new student and return the created row (id, student_id, name, grade_level)."""
     sql = """
         INSERT INTO students (student_id, name, grade_level)
@@ -72,5 +74,70 @@ def add_student(student_id: int, name: str, grade_level: int):
                 cur.execute(sql, (student_id, name, grade_level))
                 row = cur.fetchone()
                 return row
+    finally:
+        conn.close()
+
+
+def get_student(student_id: str):
+    """Fetch a single student row by ``student_id``."""
+    sql = (
+        "SELECT id, student_id, name, grade_level FROM students WHERE student_id=%s"
+    )
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, (student_id,))
+            return cur.fetchone()
+    finally:
+        conn.close()
+
+
+def update_student(
+    student_id: str, name: Optional[str] = None, grade_level: Optional[int] = None
+):
+    """
+    Update an existing student and return the updated row.
+
+    At least one of ``name`` or ``grade_level`` must be provided.
+    """
+
+    fields = []
+    values = []
+    if name is not None:
+        fields.append("name=%s")
+        values.append(name)
+    if grade_level is not None:
+        fields.append("grade_level=%s")
+        values.append(grade_level)
+    if not fields:
+        raise ValueError("No fields to update")
+    values.append(student_id)
+
+    sql = f"""
+        UPDATE students
+        SET {', '.join(fields)}
+        WHERE student_id=%s
+        RETURNING id, student_id, name, grade_level;
+    """
+
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, tuple(values))
+                return cur.fetchone()
+    finally:
+        conn.close()
+
+
+def delete_student(student_id: str) -> bool:
+    """Delete a student by ``student_id``. Returns ``True`` if a row was deleted."""
+    sql = "DELETE FROM students WHERE student_id=%s"
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (student_id,))
+                return cur.rowcount > 0
     finally:
         conn.close()

--- a/tests/test_students_crud.py
+++ b/tests/test_students_crud.py
@@ -1,0 +1,47 @@
+from db import (
+    add_student,
+    delete_student,
+    get_connection,
+    get_student,
+    update_student,
+)
+
+
+def test_get_student_fetches_row():
+    add_student("S1", "Alice", 10)
+    fetched = get_student("S1")
+    assert fetched[1:] == ("S1", "Alice", 10)
+
+
+def test_update_student_modifies_row():
+    add_student("S1", "Alice", 10)
+    updated = update_student("S1", name="Alicia", grade_level=11)
+    assert updated[1:] == ("S1", "Alicia", 11)
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT student_id, name, grade_level FROM students WHERE student_id=%s",
+                ("S1",),
+            )
+            assert cur.fetchone() == ("S1", "Alicia", 11)
+    finally:
+        conn.close()
+
+
+def test_delete_student_removes_row():
+    add_student("S1", "Alice", 10)
+    assert delete_student("S1") is True
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM students WHERE student_id=%s",
+                ("S1",),
+            )
+            assert cur.fetchone() is None
+    finally:
+        conn.close()
+


### PR DESCRIPTION
## Summary
- add get_student, update_student, and delete_student helpers for student records
- cover new helpers with CRUD tests

## Testing
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a569b2b31083338b72777d4eed62f9