### PR TITLE
Add data models and CRUD repositories with tests

### DIFF
--- a/models/class_sections.py
+++ b/models/class_sections.py
@@ -1,0 +1,91 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from db import get_connection
+
+
+@dataclass
+class ClassSection:
+    id: Optional[int]
+    course_id: Optional[int]
+    section_name: Optional[str]
+    max_students: int = 24
+    semester: Optional[str] = None
+    is_active: bool = True
+
+
+def create_class_section(
+    course_id: Optional[int] = None,
+    section_name: Optional[str] = None,
+    max_students: int = 24,
+    semester: Optional[str] = None,
+    is_active: bool = True,
+) -> ClassSection:
+    sql = """
+        INSERT INTO class_sections (course_id, section_name, max_students, semester, is_active)
+        VALUES (%s,%s,%s,%s,%s)
+        RETURNING id, course_id, section_name, max_students, semester, is_active;
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql,
+                    (course_id, section_name, max_students, semester, is_active),
+                )
+                row = cur.fetchone()
+                return ClassSection(*row)
+    finally:
+        conn.close()
+
+
+def get_class_section(section_id: int) -> Optional[ClassSection]:
+    sql = """
+        SELECT id, course_id, section_name, max_students, semester, is_active
+        FROM class_sections WHERE id=%s
+    """
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, (section_id,))
+            row = cur.fetchone()
+            return ClassSection(*row) if row else None
+    finally:
+        conn.close()
+
+
+def update_class_section(section_id: int, **fields) -> ClassSection:
+    if not fields:
+        raise ValueError("No fields to update")
+    cols = []
+    vals = []
+    for k, v in fields.items():
+        cols.append(f"{k}=%s")
+        vals.append(v)
+    vals.append(section_id)
+    sql = f"""
+        UPDATE class_sections SET {', '.join(cols)} WHERE id=%s
+        RETURNING id, course_id, section_name, max_students, semester, is_active
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, tuple(vals))
+                row = cur.fetchone()
+                return ClassSection(*row)
+    finally:
+        conn.close()
+
+
+def delete_class_section(section_id: int) -> bool:
+    sql = "DELETE FROM class_sections WHERE id=%s"
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (section_id,))
+                return cur.rowcount > 0
+    finally:
+        conn.close()

--- a/models/courses.py
+++ b/models/courses.py
@@ -1,0 +1,127 @@
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+from db import get_connection
+
+
+@dataclass
+class Course:
+    id: Optional[int]
+    code: str
+    name: str
+    department: Optional[str] = None
+    periods_per_week: int = 1
+    is_mandatory: bool = False
+    is_elective: bool = False
+    requires_consecutive_periods: bool = False
+    preferred_facility_type: Optional[str] = None
+    requires_specific_facility: bool = False
+    grade_levels: Optional[Dict[str, Any]] = None
+    notes: Optional[str] = None
+
+
+def create_course(
+    code: str,
+    name: str,
+    periods_per_week: int,
+    department: Optional[str] = None,
+    is_mandatory: bool = False,
+    is_elective: bool = False,
+    requires_consecutive_periods: bool = False,
+    preferred_facility_type: Optional[str] = None,
+    requires_specific_facility: bool = False,
+    grade_levels: Optional[Dict[str, Any]] = None,
+    notes: Optional[str] = None,
+) -> Course:
+    sql = """
+        INSERT INTO courses (code, name, department, periods_per_week,
+                             is_mandatory, is_elective, requires_consecutive_periods,
+                             preferred_facility_type, requires_specific_facility,
+                             grade_levels, notes)
+        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        RETURNING id, code, name, department, periods_per_week,
+                  is_mandatory, is_elective, requires_consecutive_periods,
+                  preferred_facility_type, requires_specific_facility,
+                  grade_levels, notes;
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql,
+                    (
+                        code,
+                        name,
+                        department,
+                        periods_per_week,
+                        is_mandatory,
+                        is_elective,
+                        requires_consecutive_periods,
+                        preferred_facility_type,
+                        requires_specific_facility,
+                        grade_levels,
+                        notes,
+                    ),
+                )
+                row = cur.fetchone()
+                return Course(*row)
+    finally:
+        conn.close()
+
+
+def get_course(course_id: int) -> Optional[Course]:
+    sql = """
+        SELECT id, code, name, department, periods_per_week,
+               is_mandatory, is_elective, requires_consecutive_periods,
+               preferred_facility_type, requires_specific_facility,
+               grade_levels, notes
+        FROM courses WHERE id=%s
+    """
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, (course_id,))
+            row = cur.fetchone()
+            return Course(*row) if row else None
+    finally:
+        conn.close()
+
+
+def update_course(course_id: int, **fields) -> Course:
+    if not fields:
+        raise ValueError("No fields to update")
+    cols = []
+    vals = []
+    for k, v in fields.items():
+        cols.append(f"{k}=%s")
+        vals.append(v)
+    vals.append(course_id)
+    sql = f"""
+        UPDATE courses SET {', '.join(cols)} WHERE id=%s
+        RETURNING id, code, name, department, periods_per_week,
+                  is_mandatory, is_elective, requires_consecutive_periods,
+                  preferred_facility_type, requires_specific_facility,
+                  grade_levels, notes
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, tuple(vals))
+                row = cur.fetchone()
+                return Course(*row)
+    finally:
+        conn.close()
+
+
+def delete_course(course_id: int) -> bool:
+    sql = "DELETE FROM courses WHERE id=%s"
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (course_id,))
+                return cur.rowcount > 0
+    finally:
+        conn.close()

--- a/models/facilities.py
+++ b/models/facilities.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from db import get_connection
+
+
+@dataclass
+class Facility:
+    id: Optional[int]
+    name: str
+    facility_type: Optional[str] = None
+    capacity: int = 24
+    can_split: bool = False
+    split_capacity: Optional[int] = None
+    notes: Optional[str] = None
+
+
+def create_facility(
+    name: str,
+    facility_type: Optional[str] = None,
+    capacity: int = 24,
+    can_split: bool = False,
+    split_capacity: Optional[int] = None,
+    notes: Optional[str] = None,
+) -> Facility:
+    sql = """
+        INSERT INTO facilities (name, facility_type, capacity, can_split, split_capacity, notes)
+        VALUES (%s,%s,%s,%s,%s,%s)
+        RETURNING id, name, facility_type, capacity, can_split, split_capacity, notes;
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql,
+                    (name, facility_type, capacity, can_split, split_capacity, notes),
+                )
+                row = cur.fetchone()
+                return Facility(*row)
+    finally:
+        conn.close()
+
+
+def get_facility(facility_id: int) -> Optional[Facility]:
+    sql = """
+        SELECT id, name, facility_type, capacity, can_split, split_capacity, notes
+        FROM facilities WHERE id=%s
+    """
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, (facility_id,))
+            row = cur.fetchone()
+            return Facility(*row) if row else None
+    finally:
+        conn.close()
+
+
+def update_facility(facility_id: int, **fields) -> Facility:
+    if not fields:
+        raise ValueError("No fields to update")
+    cols = []
+    vals = []
+    for k, v in fields.items():
+        cols.append(f"{k}=%s")
+        vals.append(v)
+    vals.append(facility_id)
+    sql = f"""
+        UPDATE facilities SET {', '.join(cols)} WHERE id=%s
+        RETURNING id, name, facility_type, capacity, can_split, split_capacity, notes
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, tuple(vals))
+                row = cur.fetchone()
+                return Facility(*row)
+    finally:
+        conn.close()
+
+
+def delete_facility(facility_id: int) -> bool:
+    sql = "DELETE FROM facilities WHERE id=%s"
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (facility_id,))
+                return cur.rowcount > 0
+    finally:
+        conn.close()

--- a/models/teachers.py
+++ b/models/teachers.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+
+from db import get_connection
+
+
+@dataclass
+class Teacher:
+    id: Optional[int]
+    name: str
+    employee_id: Optional[str] = None
+    max_periods_per_week: int = 24
+    is_international: bool = False
+    can_supervise_study_hours: bool = True
+    departments: Optional[Dict[str, Any]] = None
+    preferred_periods: Optional[Dict[str, Any]] = None
+    unavailable_periods: Optional[Dict[str, Any]] = None
+    notes: Optional[str] = None
+
+
+def create_teacher(
+    name: str,
+    employee_id: Optional[str] = None,
+    max_periods_per_week: int = 24,
+    is_international: bool = False,
+    can_supervise_study_hours: bool = True,
+    departments: Optional[Dict[str, Any]] = None,
+    preferred_periods: Optional[Dict[str, Any]] = None,
+    unavailable_periods: Optional[Dict[str, Any]] = None,
+    notes: Optional[str] = None,
+) -> Teacher:
+    sql = """
+        INSERT INTO teachers (name, employee_id, max_periods_per_week, is_international,
+                              can_supervise_study_hours, departments, preferred_periods,
+                              unavailable_periods, notes)
+        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        RETURNING id, name, employee_id, max_periods_per_week, is_international,
+                  can_supervise_study_hours, departments, preferred_periods,
+                  unavailable_periods, notes;
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql,
+                    (
+                        name,
+                        employee_id,
+                        max_periods_per_week,
+                        is_international,
+                        can_supervise_study_hours,
+                        departments,
+                        preferred_periods,
+                        unavailable_periods,
+                        notes,
+                    ),
+                )
+                row = cur.fetchone()
+                return Teacher(*row)
+    finally:
+        conn.close()
+
+
+def get_teacher(teacher_id: int) -> Optional[Teacher]:
+    sql = """
+        SELECT id, name, employee_id, max_periods_per_week, is_international,
+               can_supervise_study_hours, departments, preferred_periods,
+               unavailable_periods, notes
+        FROM teachers WHERE id=%s
+    """
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, (teacher_id,))
+            row = cur.fetchone()
+            return Teacher(*row) if row else None
+    finally:
+        conn.close()
+
+
+def update_teacher(teacher_id: int, **fields) -> Teacher:
+    if not fields:
+        raise ValueError("No fields to update")
+    columns = []
+    values = []
+    for key, value in fields.items():
+        columns.append(f"{key}=%s")
+        values.append(value)
+    values.append(teacher_id)
+    sql = f"""
+        UPDATE teachers SET {', '.join(columns)} WHERE id=%s
+        RETURNING id, name, employee_id, max_periods_per_week, is_international,
+                  can_supervise_study_hours, departments, preferred_periods,
+                  unavailable_periods, notes
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, tuple(values))
+                row = cur.fetchone()
+                return Teacher(*row)
+    finally:
+        conn.close()
+
+
+def delete_teacher(teacher_id: int) -> bool:
+    sql = "DELETE FROM teachers WHERE id=%s"
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (teacher_id,))
+                return cur.rowcount > 0
+    finally:
+        conn.close()

--- a/models/time_periods.py
+++ b/models/time_periods.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass
+from datetime import time
+from typing import Optional
+
+from db import get_connection
+
+
+@dataclass
+class TimePeriod:
+    id: Optional[int]
+    period_number: int
+    day_of_week: Optional[int] = None
+    period_type: str = "regular"
+    start_time: Optional[time] = None
+    end_time: Optional[time] = None
+    is_active: bool = True
+    special_notes: Optional[str] = None
+
+
+def create_time_period(
+    period_number: int,
+    day_of_week: Optional[int] = None,
+    period_type: str = "regular",
+    start_time: Optional[time] = None,
+    end_time: Optional[time] = None,
+    is_active: bool = True,
+    special_notes: Optional[str] = None,
+) -> TimePeriod:
+    sql = """
+        INSERT INTO time_periods (period_number, day_of_week, period_type,
+                                  start_time, end_time, is_active, special_notes)
+        VALUES (%s,%s,%s,%s,%s,%s,%s)
+        RETURNING id, period_number, day_of_week, period_type,
+                  start_time, end_time, is_active, special_notes;
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql,
+                    (
+                        period_number,
+                        day_of_week,
+                        period_type,
+                        start_time,
+                        end_time,
+                        is_active,
+                        special_notes,
+                    ),
+                )
+                row = cur.fetchone()
+                return TimePeriod(*row)
+    finally:
+        conn.close()
+
+
+def get_time_period(tp_id: int) -> Optional[TimePeriod]:
+    sql = """
+        SELECT id, period_number, day_of_week, period_type,
+               start_time, end_time, is_active, special_notes
+        FROM time_periods WHERE id=%s
+    """
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql, (tp_id,))
+            row = cur.fetchone()
+            return TimePeriod(*row) if row else None
+    finally:
+        conn.close()
+
+
+def update_time_period(tp_id: int, **fields) -> TimePeriod:
+    if not fields:
+        raise ValueError("No fields to update")
+    cols = []
+    vals = []
+    for k, v in fields.items():
+        cols.append(f"{k}=%s")
+        vals.append(v)
+    vals.append(tp_id)
+    sql = f"""
+        UPDATE time_periods SET {', '.join(cols)} WHERE id=%s
+        RETURNING id, period_number, day_of_week, period_type,
+                  start_time, end_time, is_active, special_notes
+    """
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, tuple(vals))
+                row = cur.fetchone()
+                return TimePeriod(*row)
+    finally:
+        conn.close()
+
+
+def delete_time_period(tp_id: int) -> bool:
+    sql = "DELETE FROM time_periods WHERE id=%s"
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (tp_id,))
+                return cur.rowcount > 0
+    finally:
+        conn.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,11 +13,13 @@ def db_env(monkeypatch):
     monkeypatch.setenv("POSTGRES_HOST", "localhost")
     monkeypatch.setenv("POSTGRES_PORT", "5432")
     init_db()
-    # clean table between tests (adjust table name if needed)
+    # clean tables between tests
     conn = get_connection()
     try:
         with conn:
             with conn.cursor() as cur:
-                cur.execute("TRUNCATE TABLE students RESTART IDENTITY CASCADE;")
+                cur.execute(
+                    "TRUNCATE TABLE students, teachers, courses, time_periods, class_sections, facilities RESTART IDENTITY CASCADE;"
+                )
     finally:
         conn.close()

--- a/tests/test_class_sections_crud.py
+++ b/tests/test_class_sections_crud.py
@@ -1,0 +1,21 @@
+from models.class_sections import (
+    create_class_section,
+    get_class_section,
+    update_class_section,
+    delete_class_section,
+)
+from models.courses import create_course
+
+
+def test_class_section_crud_cycle():
+    course = create_course("SCI101", "Science", 4)
+    section = create_class_section(course_id=course.id, section_name="A")
+    fetched = get_class_section(section.id)
+    assert fetched == section
+
+    updated = update_class_section(section.id, section_name="B", max_students=30)
+    assert updated.section_name == "B"
+    assert updated.max_students == 30
+
+    assert delete_class_section(section.id) is True
+    assert get_class_section(section.id) is None

--- a/tests/test_courses_crud.py
+++ b/tests/test_courses_crud.py
@@ -1,0 +1,18 @@
+from models.courses import (
+    create_course,
+    get_course,
+    update_course,
+    delete_course,
+)
+
+
+def test_course_crud_cycle():
+    course = create_course("MATH101", "Mathematics", 5)
+    fetched = get_course(course.id)
+    assert fetched == course
+
+    updated = update_course(course.id, name="Advanced Math")
+    assert updated.name == "Advanced Math"
+
+    assert delete_course(course.id) is True
+    assert get_course(course.id) is None

--- a/tests/test_facilities_crud.py
+++ b/tests/test_facilities_crud.py
@@ -1,0 +1,19 @@
+from models.facilities import (
+    create_facility,
+    get_facility,
+    update_facility,
+    delete_facility,
+)
+
+
+def test_facility_crud_cycle():
+    facility = create_facility("Lab1", facility_type="lab")
+    fetched = get_facility(facility.id)
+    assert fetched == facility
+
+    updated = update_facility(facility.id, name="LabA", capacity=40)
+    assert updated.name == "LabA"
+    assert updated.capacity == 40
+
+    assert delete_facility(facility.id) is True
+    assert get_facility(facility.id) is None

--- a/tests/test_teachers_crud.py
+++ b/tests/test_teachers_crud.py
@@ -1,0 +1,19 @@
+from models.teachers import (
+    create_teacher,
+    get_teacher,
+    update_teacher,
+    delete_teacher,
+)
+
+
+def test_teacher_crud_cycle():
+    teacher = create_teacher("Alice")
+    fetched = get_teacher(teacher.id)
+    assert fetched == teacher
+
+    updated = update_teacher(teacher.id, name="Alicia", max_periods_per_week=20)
+    assert updated.name == "Alicia"
+    assert updated.max_periods_per_week == 20
+
+    assert delete_teacher(teacher.id) is True
+    assert get_teacher(teacher.id) is None

--- a/tests/test_time_periods_crud.py
+++ b/tests/test_time_periods_crud.py
@@ -1,0 +1,20 @@
+from datetime import time
+
+from models.time_periods import (
+    create_time_period,
+    get_time_period,
+    update_time_period,
+    delete_time_period,
+)
+
+
+def test_time_period_crud_cycle():
+    tp = create_time_period(1, day_of_week=1, start_time=time(8, 0), end_time=time(8, 45))
+    fetched = get_time_period(tp.id)
+    assert fetched == tp
+
+    updated = update_time_period(tp.id, period_number=2)
+    assert updated.period_number == 2
+
+    assert delete_time_period(tp.id) is True
+    assert get_time_period(tp.id) is None


### PR DESCRIPTION
## Summary
- add dataclass models for teachers, courses, time periods, class sections and facilities
- implement CRUD helper functions using `db.get_connection`
- expand test suite to cover CRUD cycles for new entities and update fixtures

## Testing
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fded20ec833390827371074a6f74