### PR TITLE
Add CP-SAT timetable solver and tests

### DIFF
--- a/scheduler/solver.py
+++ b/scheduler/solver.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Tuple
+
+from ortools.sat.python import cp_model
+
+from db import get_connection
+
+
+Assignment = Tuple[int, int, int, int]  # class_section_id, teacher_id, facility_id, period_id
+
+
+def _fetch_all(table: str, columns: List[str]) -> List[Tuple]:
+    """Generic helper to fetch all rows from ``table`` for ``columns``."""
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT {', '.join(columns)} FROM {table}")
+            return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def _store_schedule(assignments: List[Assignment]) -> None:
+    """Persist schedule into ``scheduled_classes`` and ``class_enrollments`` tables."""
+    if not assignments:
+        return
+
+    students = _fetch_all("students", ["id"])
+    student_ids = [s[0] for s in students]
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                for class_id, teacher_id, facility_id, period_id in assignments:
+                    # fetch semester from class_section
+                    cur.execute(
+                        "SELECT semester FROM class_sections WHERE id=%s", (class_id,)
+                    )
+                    semester = cur.fetchone()[0]
+                    cur.execute(
+                        """
+                        INSERT INTO scheduled_classes
+                            (class_section_id, teacher_id, facility_id, time_period_id, semester)
+                        VALUES (%s,%s,%s,%s,%s)
+                        RETURNING id;
+                        """,
+                        (class_id, teacher_id, facility_id, period_id, semester),
+                    )
+                    scheduled_id = cur.fetchone()[0]
+                    for sid in student_ids:
+                        cur.execute(
+                            "INSERT INTO class_enrollments (scheduled_class_id, student_id) VALUES (%s,%s)",
+                            (scheduled_id, sid),
+                        )
+    finally:
+        conn.close()
+
+
+def solve() -> List[Dict[str, int]]:
+    """Solve the timetable problem and return the in-memory schedule."""
+    class_sections = _fetch_all("class_sections", ["id"])
+    teachers = _fetch_all(
+        "teachers", ["id", "max_periods_per_week", "preferred_periods"]
+    )
+    facilities = _fetch_all("facilities", ["id"])
+    periods = _fetch_all("time_periods", ["id"])
+
+    model = cp_model.CpModel()
+
+    vars: Dict[Assignment, cp_model.IntVar] = {}
+    for c in class_sections:
+        for t in teachers:
+            for f in facilities:
+                for p in periods:
+                    vars[(c[0], t[0], f[0], p[0])] = model.NewBoolVar(
+                        f"c{c[0]}_t{t[0]}_f{f[0]}_p{p[0]}"
+                    )
+
+    # each class scheduled exactly once
+    for c in class_sections:
+        model.Add(
+            sum(
+                vars[(c[0], t[0], f[0], p[0])]
+                for t in teachers
+                for f in facilities
+                for p in periods
+            )
+            == 1
+        )
+
+    # teacher load limits and one class per period
+    for t in teachers:
+        model.Add(
+            sum(
+                vars[(c[0], t[0], f[0], p[0])]
+                for c in class_sections
+                for f in facilities
+                for p in periods
+            )
+            <= t[1]
+        )
+        for p in periods:
+            model.Add(
+                sum(
+                    vars[(c[0], t[0], f[0], p[0])]
+                    for c in class_sections
+                    for f in facilities
+                )
+                <= 1
+            )
+
+    # facility conflicts
+    for f in facilities:
+        for p in periods:
+            model.Add(
+                sum(
+                    vars[(c[0], t[0], f[0], p[0])]
+                    for c in class_sections
+                    for t in teachers
+                )
+                <= 1
+            )
+
+    # soft constraint: teacher preferred periods
+    penalty_terms = []
+    for c in class_sections:
+        for t in teachers:
+            pref_periods = set()
+            if t[2]:
+                try:
+                    data = json.loads(t[2])
+                    if isinstance(data, dict):
+                        pref_periods = set(data.get("preferred", []))
+                    elif isinstance(data, list):
+                        pref_periods = set(data)
+                except json.JSONDecodeError:
+                    pass
+            for f in facilities:
+                for p in periods:
+                    v = vars[(c[0], t[0], f[0], p[0])]
+                    if p[0] not in pref_periods:
+                        penalty_terms.append(v)
+    if penalty_terms:
+        model.Minimize(sum(penalty_terms))
+
+    solver = cp_model.CpSolver()
+    result = solver.Solve(model)
+    if result not in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        raise RuntimeError("No feasible schedule found")
+
+    assignments: List[Assignment] = []
+    schedule: List[Dict[str, int]] = []
+    for key, var in vars.items():
+        if solver.Value(var):
+            assignments.append(key)
+            schedule.append(
+                {
+                    "class_section_id": key[0],
+                    "teacher_id": key[1],
+                    "facility_id": key[2],
+                    "time_period_id": key[3],
+                }
+            )
+
+    _store_schedule(assignments)
+    return schedule

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def db_env(monkeypatch):
         with conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "TRUNCATE TABLE students, teachers, courses, time_periods, class_sections, facilities RESTART IDENTITY CASCADE;"
+                    "TRUNCATE TABLE students, teachers, courses, time_periods, class_sections, facilities, scheduled_classes, class_enrollments RESTART IDENTITY CASCADE;"
                 )
     finally:
         conn.close()

--- a/tests/test_scheduler_solver.py
+++ b/tests/test_scheduler_solver.py
@@ -1,0 +1,55 @@
+from scheduler.solver import solve
+from models.courses import create_course
+from models.class_sections import create_class_section
+from models.teachers import create_teacher
+from models.facilities import create_facility
+from models.time_periods import create_time_period
+from db import add_student, get_connection
+
+
+def test_solver_returns_feasible_timetable():
+    period1 = create_time_period(period_number=1, day_of_week=1)
+    period2 = create_time_period(period_number=2, day_of_week=1)
+    teacher1 = create_teacher(
+        name="T1", max_periods_per_week=1, preferred_periods={"preferred": [period1.id]}
+    )
+    teacher2 = create_teacher(
+        name="T2", max_periods_per_week=1, preferred_periods={"preferred": [period2.id]}
+    )
+    facility = create_facility(name="Room 1")
+    course1 = create_course(code="M1", name="Math", periods_per_week=1)
+    course2 = create_course(code="E1", name="Eng", periods_per_week=1)
+    section1 = create_class_section(course_id=course1.id, section_name="A", semester="2024")
+    section2 = create_class_section(course_id=course2.id, section_name="B", semester="2024")
+    add_student("S1", "Student One", 10)
+
+    schedule = solve()
+    assert len(schedule) == 2
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT class_section_id, teacher_id, facility_id, time_period_id FROM scheduled_classes ORDER BY class_section_id"
+            )
+            rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    assert len(rows) == 2
+    # teachers assigned to their preferred periods
+    assignment_map = {row[0]: row for row in rows}
+    assert assignment_map[section1.id][1] == teacher1.id
+    assert assignment_map[section1.id][3] == period1.id
+    assert assignment_map[section2.id][1] == teacher2.id
+    assert assignment_map[section2.id][3] == period2.id
+
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM class_enrollments")
+            enroll_count = cur.fetchone()[0]
+    finally:
+        conn.close()
+
+    assert enroll_count == 2  # two scheduled classes with one student each


### PR DESCRIPTION
## Summary
- implement CP-SAT-based solver that schedules class sections to teachers, facilities, and periods with hard/soft constraints
- persist generated schedule into `scheduled_classes` and `class_enrollments` tables
- add tests exercising solver on sample data and reset new tables between runs

## Testing
- `pytest tests/test_scheduler_solver.py -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a62705dba48333835464a801f7aa0e