### PR TITLE
Convert dict fields to JSON strings when creating teachers

### DIFF
--- a/models/teachers.py
+++ b/models/teachers.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional, Dict, Any
+import json
 
 from db import get_connection
 
@@ -50,9 +51,9 @@ def create_teacher(
                         max_periods_per_week,
                         is_international,
                         can_supervise_study_hours,
-                        departments,
-                        preferred_periods,
-                        unavailable_periods,
+                        json.dumps(departments) if isinstance(departments, dict) else departments,
+                        json.dumps(preferred_periods) if isinstance(preferred_periods, dict) else preferred_periods,
+                        json.dumps(unavailable_periods) if isinstance(unavailable_periods, dict) else unavailable_periods,
                         notes,
                     ),
                 )


### PR DESCRIPTION
## Summary
- Ensure `create_teacher` converts Python `dict` values to JSON strings before sending them to psycopg2

## Testing
- `pytest -q` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a62f63ebbc83339b698005d74c7258