### PR TITLE
Refactor solver to use repository helpers

### DIFF
--- a/repository.py
+++ b/repository.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from db import get_connection
+
+Assignment = Tuple[int, int, int, int]
+
+
+def fetch_class_sections() -> List[Tuple[int]]:
+    """Return all class section IDs."""
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM class_sections")
+            return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def fetch_teachers() -> List[Tuple[int, int, str | None]]:
+    """Return all teachers with max load and preferred periods."""
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, max_periods_per_week, preferred_periods FROM teachers"
+            )
+            return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def fetch_facilities() -> List[Tuple[int]]:
+    """Return all facility IDs."""
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM facilities")
+            return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def fetch_periods() -> List[Tuple[int]]:
+    """Return all time period IDs."""
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM time_periods")
+            return cur.fetchall()
+    finally:
+        conn.close()
+
+
+def fetch_student_ids() -> List[int]:
+    """Return all student IDs."""
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT id FROM students")
+            rows = cur.fetchall()
+            return [r[0] for r in rows]
+    finally:
+        conn.close()
+
+
+def insert_scheduled_class(
+    cur, class_section_id: int, teacher_id: int, facility_id: int, period_id: int
+) -> int:
+    """Insert a scheduled class and return its ID."""
+    cur.execute(
+        "SELECT semester FROM class_sections WHERE id=%s", (class_section_id,)
+    )
+    semester = cur.fetchone()[0]
+    cur.execute(
+        """
+        INSERT INTO scheduled_classes
+            (class_section_id, teacher_id, facility_id, time_period_id, semester)
+        VALUES (%s, %s, %s, %s, %s)
+        RETURNING id;
+        """,
+        (class_section_id, teacher_id, facility_id, period_id, semester),
+    )
+    return cur.fetchone()[0]
+
+
+def bulk_enroll_students(
+    cur, scheduled_class_id: int, student_ids: List[int]
+) -> None:
+    """Enroll multiple students into ``scheduled_class_id``."""
+    if not student_ids:
+        return
+    cur.executemany(
+        "INSERT INTO class_enrollments (scheduled_class_id, student_id) VALUES (%s, %s)",
+        [(scheduled_class_id, sid) for sid in student_ids],
+    )
+
+
+def persist_schedule(assignments: List[Assignment]) -> None:
+    """Persist schedule into ``scheduled_classes`` and ``class_enrollments``."""
+    if not assignments:
+        return
+
+    student_ids = fetch_student_ids()
+    if not student_ids:
+        return
+
+    conn = get_connection()
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                for class_id, teacher_id, facility_id, period_id in assignments:
+                    scheduled_id = insert_scheduled_class(
+                        cur, class_id, teacher_id, facility_id, period_id
+                    )
+                    bulk_enroll_students(cur, scheduled_id, student_ids)
+    finally:
+        conn.close()

--- a/scheduler/solver.py
+++ b/scheduler/solver.py
@@ -1,70 +1,26 @@
 from __future__ import annotations
 
 import json
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 from ortools.sat.python import cp_model
-from db import get_connection
+from repository import (
+    Assignment,
+    fetch_class_sections,
+    fetch_facilities,
+    fetch_periods,
+    fetch_teachers,
+    persist_schedule,
+)
 from scheduler.utils import coerce_json
-
-Assignment = Tuple[int, int, int, int]  # class_section_id, teacher_id, facility_id, period_id
-
-
-def _fetch_all(table: str, columns: List[str]) -> List[Tuple]:
-    """Generic helper to fetch all rows from ``table`` for ``columns``."""
-    conn = get_connection()
-    try:
-        with conn.cursor() as cur:
-            cur.execute(f"SELECT {', '.join(columns)} FROM {table}")
-            return cur.fetchall()
-    finally:
-        conn.close()
-
-
-def _store_schedule(assignments: List[Assignment]) -> None:
-    """Persist schedule into ``scheduled_classes`` and ``class_enrollments`` tables."""
-    if not assignments:
-        return
-
-    students = _fetch_all("students", ["id"])
-    student_ids = [s[0] for s in students]
-    conn = get_connection()
-    try:
-        with conn:
-            with conn.cursor() as cur:
-                for class_id, teacher_id, facility_id, period_id in assignments:
-                    # fetch semester from class_section
-                    cur.execute(
-                        "SELECT semester FROM class_sections WHERE id=%s", (class_id,)
-                    )
-                    semester = cur.fetchone()[0]
-                    cur.execute(
-                        """
-                        INSERT INTO scheduled_classes
-                            (class_section_id, teacher_id, facility_id, time_period_id, semester)
-                        VALUES (%s,%s,%s,%s,%s)
-                        RETURNING id;
-                        """,
-                        (class_id, teacher_id, facility_id, period_id, semester),
-                    )
-                    scheduled_id = cur.fetchone()[0]
-                    for sid in student_ids:
-                        cur.execute(
-                            "INSERT INTO class_enrollments (scheduled_class_id, student_id) VALUES (%s,%s)",
-                            (scheduled_id, sid),
-                        )
-    finally:
-        conn.close()
 
 
 def solve() -> List[Dict[str, int]]:
     """Solve the timetable problem and return the in-memory schedule."""
-    class_sections = _fetch_all("class_sections", ["id"])
-    teachers = _fetch_all(
-        "teachers", ["id", "max_periods_per_week", "preferred_periods"]
-    )
-    facilities = _fetch_all("facilities", ["id"])
-    periods = _fetch_all("time_periods", ["id"])
+    class_sections = fetch_class_sections()
+    teachers = fetch_teachers()
+    facilities = fetch_facilities()
+    periods = fetch_periods()
 
     model = cp_model.CpModel()
 
@@ -163,6 +119,6 @@ def solve() -> List[Dict[str, int]]:
                 }
             )
 
-    _store_schedule(assignments)
+    persist_schedule(assignments)
     return schedule
 


### PR DESCRIPTION
## Summary
- add repository helpers for fetching entities and persisting schedules
- simplify solver to only compute assignments and delegate DB access

## Testing
- `pytest` *(fails: connection to server at "localhost" (::1), port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a75b25bcb483338088014f35ad73db