### PR TITLE
Add CLI for timetable operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,21 @@ display_students()   # print student records
 ```
 
 Tests rely on a running PostgreSQL instance. Locally ensure the server is available and the `POSTGRES_*` environment variables are set. The CI workflow uses a PostgreSQL service container so tests run automatically.
+
+## Command Line Interface
+
+The project includes a small CLI in `cli.py` for interacting with the database
+and scheduling logic:
+
+```bash
+# Initialise the schema and sample data for a semester
+python cli.py populate-db --semester 2024-fall
+
+# Generate a schedule for a semester
+python cli.py run-solver --semester 2024-fall
+
+# Export the schedule in CSV or JSON format
+python cli.py export-schedule --semester 2024-fall --format csv
+```
+
+Use the `--format` option to choose the output format (`csv` or `json`).

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,41 @@
+import click
+
+from db import init_db
+from solver import run_solver, export_schedule
+
+@click.group()
+def cli():
+    """Command line interface for the timetable system."""
+    pass
+
+@cli.command("populate-db")
+@click.option("--semester", required=True, help="Semester identifier")
+def populate_db_command(semester: str):
+    """Initialise and populate the database."""
+    init_db()
+    click.echo(f"Database initialised for semester {semester}.")
+
+@cli.command("run-solver")
+@click.option("--semester", required=True, help="Semester identifier")
+def run_solver_command(semester: str):
+    """Run the scheduling solver for a semester."""
+    run_solver(semester)
+    click.echo("Solver run complete.")
+
+@cli.command("export-schedule")
+@click.option("--semester", required=True, help="Semester identifier")
+@click.option(
+    "--format",
+    "format_",
+    default="csv",
+    show_default=True,
+    type=click.Choice(["csv", "json"], case_sensitive=False),
+    help="Output format",
+)
+def export_schedule_command(semester: str, format_: str):
+    """Export the generated schedule."""
+    export_schedule(semester, format_)
+    click.echo(f"Schedule exported in {format_} format.")
+
+if __name__ == "__main__":
+    cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pyyaml
 ortools
 pytest
 psycopg2-binary
+
+click

--- a/solver.py
+++ b/solver.py
@@ -1,0 +1,37 @@
+"""Placeholder solver and export helpers."""
+from typing import Iterable, List
+
+from db import get_students
+
+
+def run_solver(semester: str) -> List[tuple]:
+    """Run the scheduling solver.
+
+    Currently this is a placeholder that simply retrieves students from the
+    repository layer to demonstrate integration.
+    """
+    students = get_students()
+    # A real solver would build a timetable here
+    print(f"Running solver for semester {semester} with {len(students)} students")
+    return students
+
+
+def export_schedule(semester: str, output_format: str) -> str:
+    """Export schedule in the requested format.
+
+    This placeholder converts the solver output to CSV or JSON.
+    """
+    data = run_solver(semester)
+    if output_format.lower() == "json":
+        import json
+
+        return json.dumps(data)
+    else:
+        import csv
+        import io
+
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        for row in data:
+            writer.writerow(row)
+        return buffer.getvalue()


### PR DESCRIPTION
## Summary
- add `cli.py` exposing `populate-db`, `run-solver`, and `export-schedule` commands
- create placeholder `solver` module that hooks into the repository layer for exporting schedules
- document CLI usage in README and include Click in requirements

## Testing
- `python cli.py --help`
- `pytest` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d909374c8333b565925a4269b1a3